### PR TITLE
Fixing incorrect code samples in the documentation

### DIFF
--- a/docs/custom-build-type.md
+++ b/docs/custom-build-type.md
@@ -8,7 +8,7 @@ Snitcher.install(
   traceActivity = if (BuildConfig.DEBUG) {
     MyExceptionTraceActivity::class
   } else {
-    traceActivity = RestoreActivity::class,
+    RestoreActivity::class
   },
   exceptionHandler = {
     if (!BuildConfig.DEBUG) {


### PR DESCRIPTION
### Before

```kotlin
  traceActivity = if (BuildConfig.DEBUG) {
    MyExceptionTraceActivity::class
  } else {
    traceActivity = RestoreActivity::class,
  },
```

### After

```kotlin
traceActivity = if (BuildConfig.DEBUG) {
    MyExceptionTraceActivity::class
  } else {
    RestoreActivity::class
  },
```